### PR TITLE
終始情報ページの修正、検索機能の修正

### DIFF
--- a/app/controllers/financial_summaries_controller.rb
+++ b/app/controllers/financial_summaries_controller.rb
@@ -5,15 +5,15 @@ class FinancialSummariesController < ApplicationController
 
   def index
     @month = parse_month(params[:month]) || Date.today.beginning_of_month
-    @summaries = FinancialSummaryService.summarize(@month)
-    @monthly_summary = FinancialSummaryService.monthly_summary(@month)
+    @summaries = FinancialSummaryService.summarize(@month, current_user)
+    @monthly_summary = FinancialSummaryService.monthly_summary(@month, current_user)
     @formatted_food_for_month = OrderDetail.format_data_for_period(:food_for_month, @month)
     @formatted_drink_for_month = OrderDetail.format_data_for_period(:drink_for_month, @month)
   end
 
   def show
     @date = Date.parse(params[:date])
-    @daily_summary = FinancialSummaryService.daily_summary(@date)
+    @daily_summary = FinancialSummaryService.daily_summary(@date, current_user)
     @formatted_food_for_day = OrderDetail.format_data_for_period(:food_for_day, @date)
     @formatted_drink_for_day = OrderDetail.format_data_for_period(:drink_for_day, @date)
   end
@@ -21,7 +21,7 @@ class FinancialSummariesController < ApplicationController
   def compile
     begin
       date = Date.parse(params[:compile][:date])
-      if FinancialSummaryService.compile_for_date(date)
+      if FinancialSummaryService.compile_for_date(date, current_user)
         flash[:success] = t('.success', summary_date: date.strftime('%Y年%m月%d日'))
       else
         flash[:danger] = t('.records_not_found', summary_date: date.strftime('%Y年%m月%d日'))

--- a/app/controllers/financial_summaries_controller.rb
+++ b/app/controllers/financial_summaries_controller.rb
@@ -7,15 +7,15 @@ class FinancialSummariesController < ApplicationController
     @month = parse_month(params[:month]) || Date.today.beginning_of_month
     @summaries = FinancialSummaryService.summarize(@month, current_user)
     @monthly_summary = FinancialSummaryService.monthly_summary(@month, current_user)
-    @formatted_food_for_month = OrderDetail.format_data_for_period(:food_for_month, @month)
-    @formatted_drink_for_month = OrderDetail.format_data_for_period(:drink_for_month, @month)
+    @formatted_food_for_month = OrderDetail.format_data_for_period(:food_for_month, @month, current_user)
+    @formatted_drink_for_month = OrderDetail.format_data_for_period(:drink_for_month, @month, current_user)
   end
 
   def show
     @date = Date.parse(params[:date])
     @daily_summary = FinancialSummaryService.daily_summary(@date, current_user)
-    @formatted_food_for_day = OrderDetail.format_data_for_period(:food_for_day, @date)
-    @formatted_drink_for_day = OrderDetail.format_data_for_period(:drink_for_day, @date)
+    @formatted_food_for_day = OrderDetail.format_data_for_period(:food_for_day, @date, current_user)
+    @formatted_drink_for_day = OrderDetail.format_data_for_period(:drink_for_day, @date, current_user)
   end
 
   def compile

--- a/app/javascript/controllers/collapse_controller.js
+++ b/app/javascript/controllers/collapse_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="collapse"
+export default class extends Controller {
+  static targets = ["icon"];
+
+  connect() {
+    this.toggleIcon();
+  }
+
+  toggleIcon() {
+    const collapseElement = document.querySelector(
+      this.element.getAttribute("href")
+    );
+    collapseElement.addEventListener("shown.bs.collapse", () => {
+      this.iconTarget.classList.remove("fa-magnifying-glass-plus");
+      this.iconTarget.classList.add("fa-magnifying-glass-minus");
+    });
+
+    collapseElement.addEventListener("hidden.bs.collapse", () => {
+      this.iconTarget.classList.remove("fa-magnifying-glass-minus");
+      this.iconTarget.classList.add("fa-magnifying-glass-plus");
+    });
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application"
 
+import CollapseController from "./collapse_controller"
+application.register("collapse", CollapseController)
+
 import FlashController from "./flash_controller"
 application.register("flash", FlashController)
 

--- a/app/models/expenditure.rb
+++ b/app/models/expenditure.rb
@@ -26,6 +26,7 @@ class Expenditure < ApplicationRecord
   validates :recorded_at, presence: true
 
   scope :for_month, ->(month) { where(recorded_at: month.beginning_of_month..month.end_of_month).where.not(compiled_at: nil) }
+  scope :for_user, ->(user) { where(user: user) }
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[recorded_at status]

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -29,10 +29,10 @@ class OrderDetail < ApplicationRecord
   validates :menu_id, presence: true
   validates :receipt_id, presence: true
 
-  scope :food_for_day, ->(date, user) { joins(:menu, :receipt).where(menus: { genre: :food }, receipts: { recorded_at: date.beginning_of_day..date.end_of_day, user_id: user.id  }) }
-  scope :drink_for_day, ->(date, user) { joins(:menu, :receipt).where(menus: { genre: :drink }, receipts: { recorded_at: date.beginning_of_day..date.end_of_day, user_id: user.id  }) }
-  scope :food_for_month, ->(month, user) { joins(:menu, :receipt).where(menus: { genre: :food }, receipts: { compiled_at: month.beginning_of_month..month.end_of_month, user_id: user.id  }) }
-  scope :drink_for_month, ->(month, user) { joins(:menu, :receipt).where(menus: { genre: :drink }, receipts: { compiled_at: month.beginning_of_month..month.end_of_month, user_id: user.id  }) }
+  scope :food_for_day, ->(date, user) { joins(:menu, :receipt).where(menus: { genre: :food }, receipts: { recorded_at: date.beginning_of_day..date.end_of_day, user_id: user.id }) }
+  scope :drink_for_day, ->(date, user) { joins(:menu, :receipt).where(menus: { genre: :drink }, receipts: { recorded_at: date.beginning_of_day..date.end_of_day, user_id: user.id }) }
+  scope :food_for_month, ->(month, user) { joins(:menu, :receipt).where(menus: { genre: :food }, receipts: { compiled_at: month.beginning_of_month..month.end_of_month, user_id: user.id }) }
+  scope :drink_for_month, ->(month, user) { joins(:menu, :receipt).where(menus: { genre: :drink }, receipts: { compiled_at: month.beginning_of_month..month.end_of_month, user_id: user.id }) }
 
   # 特定の注文の合計金額を返す
   def order_price

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -29,10 +29,10 @@ class OrderDetail < ApplicationRecord
   validates :menu_id, presence: true
   validates :receipt_id, presence: true
 
-  scope :food_for_day, ->(date) { joins(:menu, :receipt).where(menus: { genre: :food }, receipts: { recorded_at: date.beginning_of_day..date.end_of_day }) }
-  scope :drink_for_day, ->(date) { joins(:menu, :receipt).where(menus: { genre: :drink }, receipts: { recorded_at: date.beginning_of_day..date.end_of_day }) }
-  scope :food_for_month, ->(month) { joins(:menu, :receipt).where(menus: { genre: :food }, receipts: { compiled_at: month.beginning_of_month..month.end_of_month }) }
-  scope :drink_for_month, ->(month) { joins(:menu, :receipt).where(menus: { genre: :drink }, receipts: { compiled_at: month.beginning_of_month..month.end_of_month }) }
+  scope :food_for_day, ->(date, user) { joins(:menu, :receipt).where(menus: { genre: :food }, receipts: { recorded_at: date.beginning_of_day..date.end_of_day, user_id: user.id  }) }
+  scope :drink_for_day, ->(date, user) { joins(:menu, :receipt).where(menus: { genre: :drink }, receipts: { recorded_at: date.beginning_of_day..date.end_of_day, user_id: user.id  }) }
+  scope :food_for_month, ->(month, user) { joins(:menu, :receipt).where(menus: { genre: :food }, receipts: { compiled_at: month.beginning_of_month..month.end_of_month, user_id: user.id  }) }
+  scope :drink_for_month, ->(month, user) { joins(:menu, :receipt).where(menus: { genre: :drink }, receipts: { compiled_at: month.beginning_of_month..month.end_of_month, user_id: user.id  }) }
 
   # 特定の注文の合計金額を返す
   def order_price
@@ -45,8 +45,8 @@ class OrderDetail < ApplicationRecord
   end
 
   # 　 円グラフで使用
-  def self.format_data_for_period(scope_name, period)
-    order_details = send(scope_name, period).includes(:menu)
+  def self.format_data_for_period(scope_name, period, user)
+    order_details = send(scope_name, period, user).includes(:menu)
     # menu_idごとにorder_detailsをグループ化して各グループの数量を合計
     grouped_details = order_details.group_by(&:menu_id).transform_values { |details| details.sum(&:quantity) }
     # メニュー情報をmenu_idをキーとして事前に取得し、検索用のハッシュを作成

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -40,6 +40,7 @@ class Receipt < ApplicationRecord
   validates :user_id, presence: true, on: :create
 
   scope :for_month, ->(month) { where(recorded_at: month.beginning_of_month..month.end_of_month).where.not(compiled_at: nil) }
+  scope :for_user, ->(user) { where(user: user) }
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[recorded_at status]

--- a/app/views/expenditures/index.html.slim
+++ b/app/views/expenditures/index.html.slim
@@ -6,10 +6,14 @@
 
   .card
     .card-body
-      = link_to t('new'), new_expenditure_path, class: 'btn btn-primary ms-auto mb-3'
+      .d-flex.justify-content-center.d-md-block
+        = link_to t('.expenditure_entry'), new_expenditure_path, class: 'btn btn-primary mb-3 me-3'
+        a[data-bs-toggle="collapse" data-controller="collapse" data-action="click->collapse#toggleIcon" href="#collapseExample" role="button" aria-expanded="false" aria-controls="collapseExample"]
+          i.fa.fa-magnifying-glass-plus.fa-2x style="color: #B197FC;" data-collapse-target="icon"
 
-      #search-form.mt-3.mb-5
-        = render 'search_form'
+      .collapse#collapseExample
+        #search-form.mt-3.mb-5
+          = render 'search_form'
 
       .table-responsive
         table.table

--- a/app/views/menus/index.html.slim
+++ b/app/views/menus/index.html.slim
@@ -4,7 +4,7 @@
   .text-center
     h1 = "#{Menu.model_name.human}#{t('index')}"
   - if policy(Menu).create?
-    = link_to t('.menu_register'), new_menu_path, class: 'btn btn-primary mb-2 w-25'
+    = link_to t('.menu_register'), new_menu_path, class: 'btn btn-primary btn-lg mb-3 mt-4 mt-md-0'
 
   .card.mb-3
     .card-body

--- a/app/views/receipts/index.html.slim
+++ b/app/views/receipts/index.html.slim
@@ -23,10 +23,13 @@
   .index
     .card.mt-5
       .card-body
-        .mb-4
-          h3 = "#{Receipt.model_name.human}#{t('index')}"
-        #search-form.mt-3.mb-5
-          = render 'search_form'
+        .d-flex.mb-4
+          h3.me-3 = "#{Receipt.model_name.human}#{t('index')}"
+          a[data-bs-toggle="collapse" data-controller="collapse" data-action="click->collapse#toggleIcon" href="#collapseExample" role="button" aria-expanded="false" aria-controls="collapseExample"]
+            i.fa.fa-magnifying-glass-plus.fa-2x style="color: #B197FC;" data-collapse-target="icon"
+        .collapse#collapseExample      
+          #search-form.mt-3.mb-5
+            = render 'search_form'
         .table-responsive
           table.table
             thead

--- a/config/locales/resources.ja.yml
+++ b/config/locales/resources.ja.yml
@@ -38,6 +38,9 @@ ja:
     order_detail_form:
       select: 選択してください
       entry: 追加する
+  expenditures:
+    index:
+      expenditure_entry: 経費入力フォームへ進む
   financial_summaries:
     index:
       title: 収支情報

--- a/spec/models/order_detail_spec.rb
+++ b/spec/models/order_detail_spec.rb
@@ -113,6 +113,8 @@ RSpec.describe OrderDetail, type: :model do
   end
 
   describe 'Class method' do
+    let(:user) { create(:user) }
+
     describe '.total_by_genre' do
       let!(:food) { create(:menu, genre: 'food', price: 100) }
       let!(:drink) { create(:menu, genre: 'drink', price: 200) }
@@ -132,8 +134,8 @@ RSpec.describe OrderDetail, type: :model do
       context 'with month' do
         let(:food) { create(:menu, id: 1, genre: :food, category: 'food', price: 100) }
         let(:drink) { create(:menu, id: 2, genre: :drink, category: 'drink', price: 200) }
-        let(:receipt_a) { create(:receipt, compiled_at: Date.new(2024, 6, 3)) }
-        let(:receipt_b) { create(:receipt, compiled_at: Date.new(2024, 6, 2)) }
+        let(:receipt_a) { create(:receipt, compiled_at: Date.new(2024, 6, 3), user:) }
+        let(:receipt_b) { create(:receipt, compiled_at: Date.new(2024, 6, 2), user:) }
         let(:month) { Date.new(2024, 6, 1) }
 
         before do
@@ -144,15 +146,15 @@ RSpec.describe OrderDetail, type: :model do
         end
 
         it 'キーがフォーマット化され、値が合計されたハッシュで返ってくる' do
-          expect(OrderDetail.format_data_for_period(:food_for_month, month)).to eq({ 'food: 100円' => 8 })
-          expect(OrderDetail.format_data_for_period(:drink_for_month, month)).to eq({ 'drink: 200円' => 5 })
+          expect(OrderDetail.format_data_for_period(:food_for_month, month, user)).to eq({ 'food: 100円' => 8 })
+          expect(OrderDetail.format_data_for_period(:drink_for_month, month, user)).to eq({ 'drink: 200円' => 5 })
         end
       end
 
       context 'with day' do
         let!(:food) { create(:menu, genre: :food, category: 'food', price: 100) }
         let!(:drink) { create(:menu, genre: :drink, category: 'drink', price: 200) }
-        let!(:receipt) { create(:receipt, recorded_at: 1.days.ago, compiled_at: 1.days.ago) }
+        let!(:receipt) { create(:receipt, recorded_at: 1.days.ago, compiled_at: 1.days.ago, user:) }
 
         before do
           create(:order_detail, menu: food, receipt:, quantity: 2)
@@ -160,8 +162,8 @@ RSpec.describe OrderDetail, type: :model do
         end
 
         it 'キーがフォーマット化され、値が合計されたハッシュで返ってくる' do
-          expect(OrderDetail.format_data_for_period(:food_for_day, receipt.recorded_at)).to eq({ 'food: 100円' => 2 })
-          expect(OrderDetail.format_data_for_period(:drink_for_day, receipt.recorded_at)).to eq({ 'drink: 200円' => 3 })
+          expect(OrderDetail.format_data_for_period(:food_for_day, receipt.recorded_at, user)).to eq({ 'food: 100円' => 2 })
+          expect(OrderDetail.format_data_for_period(:drink_for_day, receipt.recorded_at, user)).to eq({ 'drink: 200円' => 3 })
         end
       end
     end


### PR DESCRIPTION
- close #58 
- close #55
 
### 実装
- 検索機能の表示/非表示の制御（コラプス使用）
- コラプス展開時/非表示時のアイコンの切り替えをStimulusで行う
- 収支状況のコンパイルや情報表示について、ReceiptsとExpenditureのuser_idを用いてフィルタリング