### PR TITLE
伝票入力の画面遷移時の制御とその他viewの修正

### DIFF
--- a/app/controllers/receipts_controller.rb
+++ b/app/controllers/receipts_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ReceiptsController < ApplicationController
-  before_action :set_receipt, only: [:edit, :update, :destroy]
+  before_action :set_receipt, only: [:edit, :update, :destroy, :destroy_unload]
   before_action :authorize_receipt
   before_action :set_total_values_by_genre, only: [:edit, :update]
 
@@ -44,6 +44,17 @@ class ReceiptsController < ApplicationController
     @receipt.destroy
     flash[:success] = "#{Receipt.model_name.human}#{t('delete_success')}"
     redirect_to receipts_path
+  end
+
+  def destroy
+    @receipt.destroy
+    flash[:success] = "#{Receipt.model_name.human}#{t('delete_success')}"
+    redirect_to receipts_path
+  end
+
+  def destroy_unload
+    @receipt.destroy
+    head :no_content
   end
 
   private

--- a/app/controllers/receipts_controller.rb
+++ b/app/controllers/receipts_controller.rb
@@ -46,12 +46,6 @@ class ReceiptsController < ApplicationController
     redirect_to receipts_path
   end
 
-  def destroy
-    @receipt.destroy
-    flash[:success] = "#{Receipt.model_name.human}#{t('delete_success')}"
-    redirect_to receipts_path
-  end
-
   def destroy_unload
     @receipt.destroy
     head :no_content

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -12,3 +12,6 @@ application.register("flash", FlashController)
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import UnloadController from "./unload_controller"
+application.register("unload", UnloadController)

--- a/app/javascript/controllers/unload_controller.js
+++ b/app/javascript/controllers/unload_controller.js
@@ -1,0 +1,49 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="unload"
+export default class extends Controller {
+  connect() {
+    this.formSubmitting = false;
+
+    this.element.addEventListener("submit", () => {
+      this.formSubmitting = true;
+    });
+
+    document.addEventListener("turbo:before-visit", this.confirmNavigation);
+  }
+
+  disconnect() {
+    document.removeEventListener("turbo:before-visit", this.confirmNavigation);
+  }
+
+  confirmNavigation = (event) => {
+    if (this.formSubmitting) {
+      return;
+    }
+
+    if (!confirm("入力内容は失われます。ページを離れますか？")) {
+      event.preventDefault();
+    } else {
+      this.deleteReceipt();
+    }
+  };
+
+  deleteReceipt() {
+    fetch(`/receipts/${this.data.get("receiptId")}/destroy_unload`, {
+      method: "DELETE",
+      headers: {
+        "X-CSRF-Token": document
+          .querySelector('meta[name="csrf-token"]')
+          .getAttribute("content"),
+        "Content-Type": "application/json",
+      },
+    }).then((response) => {
+      if (response.ok) {
+        // ページ全体をリロード
+        Turbo.visit(window.location.href, { action: "replace" });
+      } else {
+        console.error("伝票の削除に失敗");
+      }
+    });
+  }
+}

--- a/app/policies/receipt_policy.rb
+++ b/app/policies/receipt_policy.rb
@@ -17,6 +17,10 @@ class ReceiptPolicy < ApplicationPolicy
     update?
   end
 
+  def destroy_unload?
+    update?
+  end
+
   def permitted_attributes_for_create
     [:user_id, :status, :recorded_at]
   end

--- a/app/views/expenditures/_form.html.slim
+++ b/app/views/expenditures/_form.html.slim
@@ -10,4 +10,4 @@
       = f.hidden_field :status, value: :unrecorded
   .form-actions
     .text-end.mt-3
-      = f.button :submit, class: 'btn btn-primary'
+      = f.submit t('.update_expenditure'), class: 'btn btn-primary'

--- a/app/views/receipts/edit.html.slim
+++ b/app/views/receipts/edit.html.slim
@@ -1,25 +1,25 @@
-#form
-  .row.justify-content-center
-    .col-md-8.text-center.mb-4
-      h3 = "#{l @receipt.recorded_at, format: :long} #{t('.order_entry')}"
+div data-controller="unload" data-unload-receipt-id="#{@receipt.id}"
+  #form
+    .row.justify-content-center
+      .col-md-8.text-center.mb-4
+        h3 = "#{l @receipt.recorded_at, format: :long} #{t('.order_entry')}"
 
-    .col-md-8
-      = turbo_frame_tag 'order_form' do
-        = render 'order_detail_form', order_detail: @order_detail, menus: @menus, receipt: @receipt
+      .col-md-8
+        = turbo_frame_tag 'order_form' do
+          = render 'order_detail_form', order_detail: @order_detail, menus: @menus, receipt: @receipt
 
-    .col-md-8.mt-4
-      = turbo_frame_tag 'order_details' do
-        - @order_details.each do |order_detail|
-          = render 'order_details', order_detail: order_detail
+      .col-md-8.mt-4
+        = turbo_frame_tag 'order_details' do
+          - @order_details.each do |order_detail|
+            = render 'order_details', order_detail: order_detail
 
-        .d-flex.justify-content-between.mt-2
-          p = "#{t('.food_total')}: #{@food_value}#{t('yen')}"
-          p = "#{t('.drink_total')}: #{@drink_value}#{t('yen')}"
-          p = "#{t('.total')}: #{@food_value + @drink_value}#{t('yen')}"
+          .d-flex.justify-content-between.mt-2
+            p = "#{t('.food_total')}: #{@food_value}#{t('yen')}"
+            p = "#{t('.drink_total')}: #{@drink_value}#{t('yen')}"
+            p = "#{t('.total')}: #{@food_value + @drink_value}#{t('yen')}"
 
-    .col-md-8.text-center.mt-5
-      = simple_form_for(@receipt, url: receipt_path, method: :patch) do |f|
-        = f.hidden_field :food_value, value: @food_value
-        = f.hidden_field :drink_value, value: @drink_value
-        = f.submit t('.update_receipt'), class: 'btn btn-primary'
-
+      .col-md-8.text-center.mt-5
+        = simple_form_for(@receipt, url: receipt_path, method: :patch) do |f|
+          = f.hidden_field :food_value, value: @food_value
+          = f.hidden_field :drink_value, value: @drink_value
+          = f.submit t('.update_receipt'), class: 'btn btn-primary'

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -12,8 +12,8 @@ div.offcanvas.offcanvas-start tabindex='-1' id='offcanvasExample' aria-labelledb
       = render 'shared/menu'
     - else
       .mt-3.ms-2
-        i.fa-solid.fa-right-to-bracket.fa-fw.me-3
+        i.fa-solid.fa-right-to-bracket.fa-fw.fa-2x.me-1
         = link_to t('login'), login_path, class: 'link-light link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover'
       .mt-3.ms-2
-        i.fa-solid.fa-user-large.me-3
+        i.fa-solid.fa-user-large.fa-fw.fa-2x.me-1
         = link_to t('guest_login'), guest_login_path, class: 'link-light link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover'

--- a/config/locales/resources.ja.yml
+++ b/config/locales/resources.ja.yml
@@ -37,10 +37,12 @@ ja:
       update_receipt: 伝票を登録する
     order_detail_form:
       select: 選択してください
-      entry: 追加する
+      entry: 追加
   expenditures:
     index:
       expenditure_entry: 経費入力フォームへ進む
+    form:
+      update_expenditure: 経費を登録する
   financial_summaries:
     index:
       title: 収支情報

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,10 +14,17 @@ Rails.application.routes.draw do
 
   resources :tenants
   resources :users
+
   resources :menus do
     patch :hide, on: :member
   end
-  resources :receipts
+
+  resources :receipts do
+    member do
+      delete :destroy_unload
+    end
+  end
+
   resources :expenditures
   resources :order_details, only: [:create, :destroy]
   resources :financial_summaries, only: [:index, :show] do

--- a/spec/policies/receipt_policy_spec.rb
+++ b/spec/policies/receipt_policy_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ReceiptPolicy, type: :policy do
 
   subject { described_class }
 
-  permissions :update?, :destroy? do
+  permissions :update?, :destroy?, :destroy_unload? do
     let(:user) { create(:user) }
     let(:user_a) { create(:user) }
     let(:receipt) { create(:receipt, :update_to_record, user: user) }

--- a/spec/requests/menus_spec.rb
+++ b/spec/requests/menus_spec.rb
@@ -87,10 +87,10 @@ RSpec.describe 'Menus', type: :request do
     let(:user) { create(:user, tenant: tenant) }
 
     describe 'GET /index' do
-      it 'メニュー一覧画面に遷移する' do
+      it 'メニュー管理画面に遷移する' do
         get menus_path
         expect(response).to have_http_status(:success)
-        expect(response.body).to include('メニュー一覧')
+        expect(response.body).to include('メニュー管理')
       end
     end
 
@@ -122,7 +122,7 @@ RSpec.describe 'Menus', type: :request do
           expect { action }.to change(Menu, :count).by(1)
           expect(response).to redirect_to menus_path
           follow_redirect!
-          expect(response.body).to include('メニュー一覧')
+          expect(response.body).to include('メニュー管理')
         end
       end
 
@@ -175,11 +175,11 @@ RSpec.describe 'Menus', type: :request do
 
       subject(:action) { patch hide_menu_path(menu) }
 
-      it 'メニューが無効化され、一覧に戻る' do
+      it 'メニューが無効化され、管理画面に戻る' do
         expect { action }.to change { menu.reload.hidden_at }.from(nil).to(be_present)
         expect(response).to redirect_to menus_path
         follow_redirect!
-        expect(response.body).to include('メニュー一覧')
+        expect(response.body).to include('メニュー管理')
       end
     end
   end

--- a/spec/requests/receipts_spec.rb
+++ b/spec/requests/receipts_spec.rb
@@ -62,6 +62,18 @@ RSpec.describe 'Receipts', type: :request do
         expect(flash[:danger]).to include '操作権限がありません'
       end
     end
+
+    describe 'DELETE /destroy_unload' do
+      let!(:receipt) { create(:receipt, user: owner) }
+
+      subject(:action) { delete destroy_unload_receipt_path(receipt) }
+
+      it 'ホーム画面にリダイレクトされる' do
+        expect { action }.not_to change(Receipt, :count)
+        expect(response).to redirect_to root_path
+        expect(flash[:danger]).to include '操作権限がありません'
+      end
+    end
   end
 
   describe 'with user' do
@@ -130,6 +142,16 @@ RSpec.describe 'Receipts', type: :request do
       it 'オブジェクトが削除される' do
         expect { action }.to change(Receipt, :count).by(-1)
         expect(response).to redirect_to receipts_path
+      end
+    end
+
+    describe 'DELETE /destroy_unload' do
+      let!(:receipt) { create(:receipt, user:) }
+
+      subject(:action) { delete destroy_unload_receipt_path(receipt) }
+
+      it 'オブジェクトが削除される' do
+        expect { action }.to change(Receipt, :count).by(-1)
       end
     end
   end


### PR DESCRIPTION
- close #63
-ボタンの表記修正など
- close #64 
- アイコンサイズの修正など
- close #52 
- stimulus controller追加
- submitボタン以外を押した時、アラートを表示する。
- アラートのOKを押した時、Receiptオブジェクトが削除される。