### PR TITLE
伝票編集時に別ボタンで遷移した時の修正、アラートの表示内容の修正

### DIFF
--- a/app/controllers/receipts_controller.rb
+++ b/app/controllers/receipts_controller.rb
@@ -30,7 +30,7 @@ class ReceiptsController < ApplicationController
   def update
     @order_details = @receipt.order_details.includes(:menu)
 
-    if @receipt.update(food_value: @food_value, drink_value: @drink_value)
+    if @receipt.update(food_value: @food_value, drink_value: @drink_value, status: :unrecorded)
       flash[:success] = "#{Receipt.model_name.human}#{t('update_success')}"
       redirect_to receipts_path
     else
@@ -47,6 +47,8 @@ class ReceiptsController < ApplicationController
   end
 
   def destroy_unload
+    return if @receipt.unrecorded? || @receipt.recorded?
+
     @receipt.destroy
     head :no_content
   end

--- a/app/javascript/controllers/unload_controller.js
+++ b/app/javascript/controllers/unload_controller.js
@@ -10,7 +10,6 @@ export default class extends Controller {
       this.formSubmitting = true;
     });
 
-    this.confirmNavigation = this.confirmNavigation.bind(this);
     document.addEventListener("turbo:before-visit", this.confirmNavigation);
   }
 
@@ -23,7 +22,17 @@ export default class extends Controller {
       return;
     }
 
-    if (!confirm("入力内容は失われます。ページを離れますか？")) {
+    const status = this.data.get("status");
+    let confirmMessage = "";
+
+    if (status === "in_progress") {
+      confirmMessage = "入力中の内容は全て失われます。ページを離れますか？";
+    } else {
+      confirmMessage =
+        "入力中の内容が伝票に反映されません。ページを離れますか？";
+    }
+
+    if (!confirm(confirmMessage)) {
       event.preventDefault();
     } else {
       this.dialogShown = true;

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -9,7 +9,7 @@
 #  drink_value :integer
 #  food_value  :integer
 #  recorded_at :date             not null
-#  status      :integer          default("unrecorded"), not null
+#  status      :integer          default("in_progress"), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  user_id     :integer          not null
@@ -29,8 +29,9 @@ class Receipt < ApplicationRecord
   has_many :order_details, dependent: :destroy
 
   enum status: {
-    unrecorded: 0, # 未計上
-    recorded: 1 # 計上済
+    in_progress: 0, # 処理中
+    unrecorded: 1, # 未計上
+    recorded: 2 # 計上済
   }
 
   validates :food_value, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 99_999 }, on: :update

--- a/app/services/financial_summary_service.rb
+++ b/app/services/financial_summary_service.rb
@@ -69,7 +69,7 @@ class FinancialSummaryService
     return false if receipts.empty? || expenditures.empty?
 
     ActiveRecord::Base.transaction do
-      receipts.update_all(compiled_at: Time.zone.now, status: 1)
+      receipts.update_all(compiled_at: Time.zone.now, status: 2)
       expenditures.update_all(compiled_at: Time.zone.now, status: 1)
     end
 

--- a/app/views/receipts/edit.html.slim
+++ b/app/views/receipts/edit.html.slim
@@ -1,4 +1,4 @@
-div data-controller="unload" data-unload-receipt-id="#{@receipt.id}"
+div data-controller="unload" data-unload-receipt-id="#{@receipt.id}" data-unload-status="#{@receipt.status}"
   #form
     .row.justify-content-center
       .col-md-8.text-center.mb-4

--- a/config/locales/enum.ja.yml
+++ b/config/locales/enum.ja.yml
@@ -9,6 +9,7 @@ ja:
         drink: ドリンク
     receipt:
       status:
+        in_progress: 処理中
         unrecorded: 未計上
         recorded: 計上済
     expenditure:

--- a/spec/factories/receipts.rb
+++ b/spec/factories/receipts.rb
@@ -9,7 +9,7 @@
 #  drink_value :integer
 #  food_value  :integer
 #  recorded_at :date             not null
-#  status      :integer          default("unrecorded"), not null
+#  status      :integer          default("in_progress"), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  user_id     :integer          not null

--- a/spec/models/receipt_spec.rb
+++ b/spec/models/receipt_spec.rb
@@ -9,7 +9,7 @@
 #  drink_value :integer
 #  food_value  :integer
 #  recorded_at :date             not null
-#  status      :integer          default("unrecorded"), not null
+#  status      :integer          default("in_progress"), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  user_id     :integer          not null

--- a/spec/requests/receipts_spec.rb
+++ b/spec/requests/receipts_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Receipts', type: :request do
     end
 
     describe 'DELETE /destroy_unload' do
-      let!(:receipt) { create(:receipt, user: owner) }
+      let!(:receipt) { create(:receipt, status: 'in_progress', user: owner) }
 
       subject(:action) { delete destroy_unload_receipt_path(receipt) }
 
@@ -146,7 +146,7 @@ RSpec.describe 'Receipts', type: :request do
     end
 
     describe 'DELETE /destroy_unload' do
-      let!(:receipt) { create(:receipt, user:) }
+      let!(:receipt) { create(:receipt, status: 'in_progress', user:) }
 
       subject(:action) { delete destroy_unload_receipt_path(receipt) }
 


### PR DESCRIPTION
- close #70 
- Receiptにステータス（in_progress）を追加
- destroy_unloadアクションは、in_progressのステータス以外では適用させない
- アラートの表示内容を変える。（unloadedのオブジェクトを編集した時に別ページに遷移した場合、編集内容は伝票データに反映させない）
- OrderDetailの内容は残るので検討の余地あり。